### PR TITLE
dodge "Warning: Accessing non-existent property 'createConnection' of module exports inside circular dependency"

### DIFF
--- a/lib/Agents.js
+++ b/lib/Agents.js
@@ -21,7 +21,7 @@
 
 // Modifications made by Brian White to work with socksv5
 
-var socks = require('../index');
+var socks = require('../lib/client');
 
 var tls = require('tls');
 var util = require('util');


### PR DESCRIPTION
Importing this package under some conditions yields a warning that is easy to address:

```
> node --trace-warnings node_modules/.bin/webpack-dev-server
(node:42950) Warning: Accessing non-existent property 'createConnection' of module exports inside circular dependency
    at emitCircularRequireWarning (internal/modules/cjs/loader.js:675:11)
    at Object.get (internal/modules/cjs/loader.js:689:5)
    at Object.<anonymous> (/Users/jhs/notes3/node_modules/@outtacontrol/socks/lib/Agents.js:140:42)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at require (internal/modules/cjs/helpers.js:93:18)
    at Object.<anonymous> (/Users/jhs/notes3/node_modules/@outtacontrol/socks/index.js:1:35)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at require (internal/modules/cjs/helpers.js:93:18)
```